### PR TITLE
better gha

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,34 +1,54 @@
 name: Publish Docker image
 
 on:
-  push:
-    branches: [ "master" ]
+  pull_request:
+    branches:
+      - master
+  # push:
+  # branches: [ "master" ]
 
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.ref }}
-          check-name: 'Run tests'
+          check-name: "Run tests"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 
-      - name: Check out the repo
-        uses: actions/checkout@v3
-
       - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        id: docker_build
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: wetterkrank/dasbot:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/dasbot:latest
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,11 +1,8 @@
 name: Publish Docker image
 
 on:
-  pull_request:
-    branches:
-      - master
-  # push:
-  # branches: [ "master" ]
+  push:
+    branches: ["master"]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Wait for tests to succeed
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           check-name: "Run tests"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,8 +47,8 @@ jobs:
           context: .
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/dasbot:latest
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,13 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
       - name: Build image
         run: |
           docker-compose -f docker-compose.test.yml build
+
       - name: Run tests
         run: |
           docker-compose -f docker-compose.test.yml run --rm tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "127.0.0.1:27017:27017"
 
   dasbot:
-    image: wetterkrank/dasbot:latest
+    image: tripleight/dasbot:latest
     container_name: dasbot_app
     links:
       - mongo
@@ -22,5 +22,5 @@ services:
     logging:
       driver: json-file
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "127.0.0.1:27017:27017"
 
   dasbot:
-    image: tripleight/dasbot:latest
+    image: wetterkrank/dasbot:latest
     container_name: dasbot_app
     links:
       - mongo


### PR DESCRIPTION
- **breaking:** use `DOCKER_TOKEN` instead of docker password for safety. Requires generating a read-write token on hub.docker.com and substituting a secret in repo settings.
- dependabot for gha
- cache docker layers
- faster: do all the preps before waiting for tests are done